### PR TITLE
Fix tsc errors

### DIFF
--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -10,7 +10,6 @@ export function ExternalLink(
     <Link
       target="_blank"
       {...props}
-      // @ts-expect-error: External URLs are not typed.
       href={props.href}
       onPress={(e) => {
         if (Platform.OS !== "web") {

--- a/components/Themed.tsx
+++ b/components/Themed.tsx
@@ -4,8 +4,7 @@
  */
 
 import { Text as DefaultText, View as DefaultView } from 'react-native';
-
-import Colors from '@/constants/Colors';
+import { Colors } from '@/constants/Colors';
 import { useColorScheme } from './useColorScheme';
 
 type ThemeProps = {

--- a/components/ui/grid/index.tsx
+++ b/components/ui/grid/index.tsx
@@ -13,7 +13,7 @@ import { cssInterop } from 'nativewind';
 import {
   useBreakpointValue,
   getBreakPointValue,
-} from '../../hooks/use-break-point-value';
+} from '../utils/use-break-point-value';
 
 const { width: DEVICE_WIDTH } = Dimensions.get('window');
 

--- a/components/ui/utils/use-break-point-value.ts
+++ b/components/ui/utils/use-break-point-value.ts
@@ -2,7 +2,7 @@ import { Dimensions, useWindowDimensions } from 'react-native';
 import { useEffect, useState } from 'react';
 
 import resolveConfig from 'tailwindcss/resolveConfig';
-import tailwindConfig from 'tailwind.config';
+import * as tailwindConfig from '../../../tailwind.config';
 
 const TailwindTheme = resolveConfig(tailwindConfig as any);
 const screenSize = TailwindTheme.theme.screens;


### PR DESCRIPTION
Fix the following tsc errors: 
```
~/Code/gluestack-app [main] $ npx tsc
components/ExternalLink.tsx:13:7 - error TS2578: Unused '@ts-expect-error' directive.

13       // @ts-expect-error: External URLs are not typed.
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

components/Themed.tsx:8:8 - error TS2613: Module '"/Users/stephen/Code/gluestack-app/constants/Colors"' has no default export. Did you mean to use 'import { Colors } from "/Users/stephen/Code/gluestack-app/constants/Colors"' instead?

8 import Colors from '@/constants/Colors';
         ~~~~~~

components/ui/grid/index.tsx:16:8 - error TS2307: Cannot find module '../../hooks/use-break-point-value' or its corresponding type declarations.

16 } from '../../hooks/use-break-point-value';
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

components/ui/utils/use-break-point-value.ts:5:8 - error TS1192: Module '"/Users/stephen/Code/gluestack-app/tailwind.config"' has no default export.

5 import tailwindConfig from 'tailwind.config';
         ~~~~~~~~~~~~~~


Found 4 errors in 4 files.

Errors  Files
     1  components/ExternalLink.tsx:13
     1  components/Themed.tsx:8
     1  components/ui/grid/index.tsx:16
     1  components/ui/utils/use-break-point-value.ts:5
```